### PR TITLE
skip socket tests that depend on ipv6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
         BAR="bar -i 30";
         BUILDOPTS="-j3 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1";
         echo "override ARCH=$ARCH" >> Make.user;
-        TESTSTORUN="all";
+        TESTSTORUN="all --skip socket";
       elif [ `uname` = "Darwin" ]; then
         brew update;
         brew install -v jq pv;


### PR DESCRIPTION
seems ipv6 isn't available on premium VM's
(is that fixable?)